### PR TITLE
Added new end point to get all Dutch insurance

### DIFF
--- a/src/TheInsuranceCompany/TIC.Domain/Impl/InsuranceDomain.cs
+++ b/src/TheInsuranceCompany/TIC.Domain/Impl/InsuranceDomain.cs
@@ -22,5 +22,10 @@ namespace TIC.DomainAPI.Impl
         {
             _insuranceProvider.AddInsurance(insurance);
         }
+
+        public IEnumerable<TravelInsurance> GetDutchTravelInsurances()
+        {
+            return _insuranceProvider.GetDutchInsurances();
+        }
     }
 }

--- a/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/GetDutchInsurancesResponseMapperTests.cs
+++ b/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/GetDutchInsurancesResponseMapperTests.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TIC.DomainModel;
+using TIC.WebAPI.Models.Responses;
+using TIC.WebAPI.Mappers.Impl;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TIC.WebAPI.Tests.Mappers
+{
+    [TestClass]
+    public class GetDutchInsurancesResponseMapperTests
+    {
+        private GetDutchInsurancesResponseMapper _mapper;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _mapper = new GetDutchInsurancesResponseMapper();
+        }
+
+        [TestMethod]
+        public void Map_ReturnsMappedTravelInsurances_WhenInsurancesExist()
+        {
+            // Arrange
+            var insurances = new List<TravelInsurance>
+            {
+                new TravelInsurance { Name = "Adventure Travel", Description = "Adventure coverage", InsurancePremium = 150m, InsuredAmount = 75000m },
+                new TravelInsurance { Name = "Business Travel", Description = "Business coverage", InsurancePremium = 250m, InsuredAmount = 150000m }
+            };
+
+            // Act
+            var response = _mapper.Map(insurances);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.DutchTravelInsurances);
+            Assert.AreEqual(2, response.DutchTravelInsurances.Count());
+            Assert.AreEqual("Adventure Travel", response.DutchTravelInsurances.First().Name);
+        }
+
+        [TestMethod]
+        public void Map_ReturnsEmptyList_WhenNoInsurancesExist()
+        {
+            // Arrange
+            var insurances = new List<TravelInsurance>(); 
+
+            // Act
+            var response = _mapper.Map(insurances);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.DutchTravelInsurances);
+            Assert.AreEqual(0, response.DutchTravelInsurances.Count());
+        }
+
+        [TestMethod]
+        public void Map_ReturnsEmptyList_WhenInputIsNull()
+        {
+            // Arrange
+            IEnumerable<TravelInsurance> insurances = null; 
+
+            // Act
+            var response = _mapper.Map(insurances);
+
+            // Assert
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.DutchTravelInsurances);
+            Assert.AreEqual(0, response.DutchTravelInsurances.Count());
+        }
+    }
+}

--- a/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/InsuranceControllerTests.cs
+++ b/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/InsuranceControllerTests.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using TIC.WebAPI.Controllers;
+using TIC.DomainAPI;
+using TIC.WebAPI.Models.Responses;
+using Microsoft.Extensions.Logging;
+using TIC.DomainModel;
+using TIC.WebAPI.Mappers;
+using TIC.WebAPI.Mappers.Impl;
+
+[TestClass]
+public class InsuranceControllerTests
+{
+    private Mock<ILogger<InsuranceController>> _loggerMock;
+    private Mock<IInsuranceDomain> _insuranceDomainMock;
+    private InsuranceController _controller;
+    private Mock<IGetDutchInsurancesResponseMapper> _mapper;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        _loggerMock = new Mock<ILogger<InsuranceController>>();
+        _insuranceDomainMock = new Mock<IInsuranceDomain>();
+        _mapper = new Mock<IGetDutchInsurancesResponseMapper>();
+        _controller = new InsuranceController(_loggerMock.Object, _insuranceDomainMock.Object, null, null, null, _mapper.Object);
+    }
+
+    [TestMethod]
+    public void GetDutchTravelInsurances_ReturnsExpectedResponse_WhenInsurancesExist()
+    {
+        // Arrange
+        var travelInsurances = new List<TravelInsurance>
+        {
+            new TravelInsurance
+            {
+                Name = "Best Travel Insurance",
+                Description = "Covers travel in the Netherlands",
+                InsurancePremium = 20m,
+                InsuredAmount = 7000
+            }
+        };
+        var res =
+          new GetDutchTravelInsuranceResponse
+          {
+              DutchTravelInsurances = new List<TravelInsuranceDto>
+              {
+                  new TravelInsuranceDto
+                { Name = "Adventure Travel", Description = "Adventure coverage", InsurancePremium = 150m, InsuredAmount = 75000m }
+              }
+          };
+      
+
+        _insuranceDomainMock.Setup(x => x.GetDutchTravelInsurances()).Returns(travelInsurances);
+        _mapper.Setup(x => x.Map(travelInsurances)).Returns(res);
+        // Act
+        var response = _controller.GetDutchTravelInsurances();
+
+        // Assert
+        Assert.IsNotNull(response);
+        Assert.IsInstanceOfType(response, typeof(GetDutchTravelInsuranceResponse));
+        var travelInsuranceList = response.DutchTravelInsurances.ToList(); 
+        Assert.AreEqual(1, travelInsuranceList.Count);
+        Assert.AreEqual("Adventure Travel", travelInsuranceList[0].Name); 
+    }
+
+    [TestMethod]
+    public void GetDutchTravelInsurances_ReturnsEmptyResponse_WhenNoInsurancesExist()
+    {
+        // Arrange
+        var travelInsurances = new List<TravelInsurance>();
+        _insuranceDomainMock.Setup(x => x.GetDutchTravelInsurances()).Returns(travelInsurances);
+
+        // Act
+        var response = _controller.GetDutchTravelInsurances();
+
+        // Assert
+        Assert.IsNull(response); 
+    }
+
+
+    [TestMethod]
+    public void GetDutchTravelInsurances_ThrowsException_WhenUnhandledExceptionOccurs()
+    {
+        // Arrange
+        _insuranceDomainMock.Setup(x => x.GetDutchTravelInsurances()).Throws(new InvalidOperationException("Unhandled exception"));
+
+        // Act & Assert
+        Assert.ThrowsException<InvalidOperationException>(() => _controller.GetDutchTravelInsurances());
+    }
+}

--- a/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/InsuranceDomainTests.cs
+++ b/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/InsuranceDomainTests.cs
@@ -45,7 +45,7 @@ namespace TIC.DomainAPI.UnitTests
                     WeightInKg = 1100
                 }
             };
-            
+
             _providerMock.Setup(x => x.GetInsurances()).Returns(getInsurancesResponse);
 
             var expectedResponse = new List<Insurance>
@@ -67,5 +67,49 @@ namespace TIC.DomainAPI.UnitTests
             // Assert
             actual.Should().BeEquivalentTo(expectedResponse);
         }
+
+        [TestMethod]
+        public void GetDutchTravelInsurances()
+        {
+            // Arrange
+            var getDutchInsurancesResponse = new List<TravelInsurance>
+            {
+                new TravelInsurance
+                {
+                    Name = "Best Travel Insurance",
+                    Description = "Insured whilst on the move",
+                    InsurancePremium = 20m,
+                    InsuredAmount = 7000,
+                    Coverage = new List<Country>
+                    {
+                        new Country { Code = "NL", Name = "Netherlands" }
+                    }
+                }
+            };
+
+            _providerMock.Setup(x => x.GetDutchInsurances()).Returns(getDutchInsurancesResponse);
+
+            var expectedResponse = new List<TravelInsurance>
+            {
+                new TravelInsurance
+                {
+                    Name = "Best Travel Insurance",
+                    Description = "Insured whilst on the move",
+                    InsurancePremium = 20m,
+                    InsuredAmount = 7000,
+                    Coverage = new List<Country>
+                    {
+                        new Country { Code = "NL", Name = "Netherlands" }
+                    }
+                }
+            };
+
+            // Act
+            var actual = _domain.GetDutchTravelInsurances();
+
+            // Assert
+            actual.Should().BeEquivalentTo(expectedResponse);
+        }
+
     }
 }

--- a/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/InsuranceProviderTests.cs
+++ b/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/InsuranceProviderTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TIC.ServiceAdapter.Models; // Update with your actual namespace
+using TIC.ServiceAdapter.Stubs; // Update with your actual namespace
+using System.Collections.Generic;
+
+namespace TIC.ServiceAdapter.Tests
+{
+    [TestClass]
+    public class InsuranceProviderTests
+    {
+        private InsuranceProvider _insuranceProvider;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _insuranceProvider = new InsuranceProvider();
+        }
+
+       
+
+        [TestMethod]
+        public void GetDutchInsurances_ShouldReturnOnlyDutchInsurances()
+        {
+            // Arrange
+          
+
+            // Act
+            var result = _insuranceProvider.GetDutchInsurances();
+
+            // Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.First().Name.Equals("Best Travel Insurance"));
+        }
+    }
+}

--- a/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/TIC.DomainAPI.UnitTests.csproj
+++ b/src/TheInsuranceCompany/TIC.DomainAPI.UnitTests/TIC.DomainAPI.UnitTests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TheInsuranceCompany\TIC.WebAPI.csproj" />
     <ProjectReference Include="..\TIC.Domain\TIC.DomainAPI.csproj" />
   </ItemGroup>
 

--- a/src/TheInsuranceCompany/TIC.ServiceAdapter/IInsuranceProvider.cs
+++ b/src/TheInsuranceCompany/TIC.ServiceAdapter/IInsuranceProvider.cs
@@ -4,4 +4,6 @@ public interface IInsuranceProvider
 {
     void AddInsurance(DomainModel.Insurance insurance);
     IEnumerable<DomainModel.Insurance> GetInsurances();
+    IEnumerable<DomainModel.TravelInsurance> GetDutchInsurances();
+
 }

--- a/src/TheInsuranceCompany/TIC.ServiceAdapter/InsuranceProvider.cs
+++ b/src/TheInsuranceCompany/TIC.ServiceAdapter/InsuranceProvider.cs
@@ -20,5 +20,11 @@ namespace TIC.ServiceAdapter
             var insurances = DatabaseStub.GetAllInsurances();
             return insurances.Map();
         }
+        public IEnumerable<DomainModel.TravelInsurance> GetDutchInsurances()
+        {
+            var travelInsurance = DatabaseStub.GetAllDutchInsurances();
+            return travelInsurance.Map().OfType<DomainModel.TravelInsurance>();
+        }
+
     }
 }

--- a/src/TheInsuranceCompany/TIC.ServiceAdapter/Stubs/DatabaseStub.cs
+++ b/src/TheInsuranceCompany/TIC.ServiceAdapter/Stubs/DatabaseStub.cs
@@ -90,5 +90,13 @@ namespace TIC.ServiceAdapter.Stubs
         {
             return Insurances;
         }
+        public static IEnumerable<Insurance> GetAllDutchInsurances()
+        {
+            return Insurances
+        .OfType<TravelInsurance>()
+        .Where(x => x.Coverage.Any(c => c.Code.Equals("NL", StringComparison.OrdinalIgnoreCase)))
+        .ToList();
+
+        }
     }
 }

--- a/src/TheInsuranceCompany/TheInsuranceCompany/Controllers/InsuranceController.cs
+++ b/src/TheInsuranceCompany/TheInsuranceCompany/Controllers/InsuranceController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using TIC.DomainAPI;
 using TIC.WebAPI.Mappers;
+using TIC.WebAPI.Models;
 using TIC.WebAPI.Models.Requests;
 using TIC.WebAPI.Models.Responses;
 
@@ -15,18 +16,21 @@ namespace TIC.WebAPI.Controllers
         private readonly IGetInsurancesRequestMapper _getInsurancesRequestMapper;
         private readonly IGetInsurancesResponseMapper _getInsurancesResponseMapper;
         private readonly IAddInsuranceRequestMapper _addInsuranceRequestMapper;
+        private readonly IGetDutchInsurancesResponseMapper _getDutchInsurancesResponseMapper;
 
-        public InsuranceController(ILogger<InsuranceController> logger, 
-            IInsuranceDomain insuranceDomain, 
-            IGetInsurancesRequestMapper getInsurancesRequestMapper, 
-            IGetInsurancesResponseMapper getInsurancesResponseMapper, 
-            IAddInsuranceRequestMapper addInsuranceRequestMapper)
+        public InsuranceController(ILogger<InsuranceController> logger,
+            IInsuranceDomain insuranceDomain,
+            IGetInsurancesRequestMapper getInsurancesRequestMapper,
+            IGetInsurancesResponseMapper getInsurancesResponseMapper,
+            IAddInsuranceRequestMapper addInsuranceRequestMapper,
+            IGetDutchInsurancesResponseMapper getDutchInsurancesResponseMapper)
         {
             _logger = logger;
             _insuranceDomain = insuranceDomain;
             _getInsurancesRequestMapper = getInsurancesRequestMapper;
             _getInsurancesResponseMapper = getInsurancesResponseMapper;
             _addInsuranceRequestMapper = addInsuranceRequestMapper;
+            _getDutchInsurancesResponseMapper = getDutchInsurancesResponseMapper;
         }
 
         [HttpPost(Name = "GetInsurances")]
@@ -53,6 +57,31 @@ namespace TIC.WebAPI.Controllers
             {
                 var domainRequest = _addInsuranceRequestMapper.Map(request);
                 _insuranceDomain.AddInsurance(domainRequest);
+            }
+            catch (Exception exception)
+            {
+                _logger.Log(LogLevel.Error, exception, exception.Message);
+                throw;
+            }
+        }
+        // <summary>
+        //We can achieve this GetDutchTravelInsurances by 2 ways , 1 by reusing GetInsurances from domain and use the conditions
+        // but  If GetAllInsurances retrieves a large dataset and we only need a small subset,
+        // it may lead to unnecessary data being processed.
+        //</summary>
+        [HttpPost(Name = "GetDutchTravelInsurances")]
+        public GetDutchTravelInsuranceResponse GetDutchTravelInsurances()
+        {
+            try
+            {
+                //        var insurances = _insuranceDomain.GetInsurances(domainRequest).OfType<TravelInsurance>()
+                //.Where(x => x.Coverage.Any(c => c.Code.Equals("NL", StringComparison.OrdinalIgnoreCase)))
+                //.ToList();
+                var insurances = _insuranceDomain.GetDutchTravelInsurances();
+                var mappedResponse = _getDutchInsurancesResponseMapper.Map(insurances);
+
+
+                return mappedResponse;
             }
             catch (Exception exception)
             {

--- a/src/TheInsuranceCompany/TheInsuranceCompany/Mappers/Impl/GetDutchInsuranceResponseMapper.cs
+++ b/src/TheInsuranceCompany/TheInsuranceCompany/Mappers/Impl/GetDutchInsuranceResponseMapper.cs
@@ -1,0 +1,24 @@
+﻿using TIC.DomainModel;
+using TIC.WebAPI.Models.Responses;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TIC.WebAPI.Mappers.Impl
+{
+    public class GetDutchInsurancesResponseMapper : IGetDutchInsurancesResponseMapper
+    {
+        public GetDutchTravelInsuranceResponse Map(IEnumerable<DomainModel.TravelInsurance> insurances)
+        {
+            return new GetDutchTravelInsuranceResponse
+            {
+                DutchTravelInsurances = insurances?.Select(insurance => new TravelInsuranceDto 
+                {
+                    Name = insurance.Name,
+                    Description = insurance.Description,
+                    InsurancePremium = insurance.InsurancePremium,
+                    InsuredAmount = insurance.InsuredAmount,
+                }).ToList() ?? new List<TravelInsuranceDto>() 
+            };
+        }
+    }
+}

--- a/src/TheInsuranceCompany/TheInsuranceCompany/Mappers/Impl/IGetDutchInsuranceResponseMapper.cs
+++ b/src/TheInsuranceCompany/TheInsuranceCompany/Mappers/Impl/IGetDutchInsuranceResponseMapper.cs
@@ -1,0 +1,10 @@
+﻿
+using TIC.WebAPI.Models.Responses;
+
+namespace TIC.WebAPI.Mappers;
+
+public interface IGetDutchInsurancesResponseMapper
+{
+    GetDutchTravelInsuranceResponse Map(IEnumerable<DomainModel.TravelInsurance> insurances);
+}
+

--- a/src/TheInsuranceCompany/TheInsuranceCompany/Models/Responses/GetDutchTravelInsuranceResponse.cs
+++ b/src/TheInsuranceCompany/TheInsuranceCompany/Models/Responses/GetDutchTravelInsuranceResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace TIC.WebAPI.Models.Responses
+{
+    public class GetDutchTravelInsuranceResponse
+    {
+        public IEnumerable<TravelInsuranceDto>? DutchTravelInsurances { get; set; }
+    }
+}

--- a/src/TheInsuranceCompany/TheInsuranceCompany/Models/Responses/TravelInsuranceDto.cs
+++ b/src/TheInsuranceCompany/TheInsuranceCompany/Models/Responses/TravelInsuranceDto.cs
@@ -1,0 +1,7 @@
+﻿namespace TIC.WebAPI.Models.Responses
+{
+    public class TravelInsuranceDto : Insurance
+    {
+        public decimal InsuredAmount { get; set; }
+    }
+}


### PR DESCRIPTION
Added one end point The 'GetDutchTravelInsurances'.
Added testcases for separate service as well.

- We can achieve this **GetDutchTravelInsurances** by 2 ways , 1 by reusing GetInsurances from domain and use the conditions
but  If GetAllInsurances retrieves a large dataset and we only need a small subset,
it may lead to unnecessary data being processed.